### PR TITLE
[#37] 크롤링 관련 API는 Token이 없어도 호출가능하도록 수정

### DIFF
--- a/src/main/java/com/gajob/config/security/SecurityConfig.java
+++ b/src/main/java/com/gajob/config/security/SecurityConfig.java
@@ -67,9 +67,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         .and()
         .authorizeRequests()
-        // 아래 세 개의 API는 Token이 없어도 호출 가능
+        // 아래 API는 Token이 없어도 호출 가능
         .antMatchers("/signup").permitAll()
         .antMatchers("/login").permitAll()
+        .antMatchers("/issue/news").permitAll()
+        .antMatchers("/issue/exhibit").permitAll()
         .anyRequest().authenticated()
 
         .and()


### PR DESCRIPTION
/issue/exhibit, /issue/news 는 Token이 없어도 접근 가능하도록 수정

