### PR TITLE
[#136] BEST3 게시물 선정을 위한 정렬 조건 추가

### DIFF
--- a/src/main/java/com/gajob/repository/posts/PostsRepository.java
+++ b/src/main/java/com/gajob/repository/posts/PostsRepository.java
@@ -18,8 +18,13 @@ public interface PostsRepository extends JpaRepository<Posts, Long> {
 
   List<Posts> findAllByUser(User user);
 
-  @Query("SELECT p FROM Posts p ORDER BY p.likes DESC")
-  List<Posts> findAllDesc();
+  // 우선 좋아요 수를 기준으로 내림차순 정렬하고, 그 다음 조회수를 기준으로 내림차순으로 다중정렬
+  @Query("SELECT p FROM Posts p ORDER BY p.likes DESC, p.view DESC")
+  List<Posts> findAllDescByLikesAndView();
+
+//  // 조회수를 기준으로 내림차순 정렬
+//  @Query("SELECT p FROM Posts p ORDER BY p.view DESC")
+//  List<Posts> findAllDescByView();
 
 
 }

--- a/src/main/java/com/gajob/service/posts/HotPostsServiceImpl.java
+++ b/src/main/java/com/gajob/service/posts/HotPostsServiceImpl.java
@@ -19,13 +19,19 @@ public class HotPostsServiceImpl implements HotPostsService {
   public List<PostsReadDto> getHotPosts() {
     List<Posts> posts = postsRepository.findAll();
 
+    // 게시물 조회시 Posts 테이블이 likes 컬럼 업데이트
+    for (Posts postList : posts) {
+      PostsReadDto postsReadDto = new PostsReadDto(postList);
+      postList.likeUpdate(postsReadDto.getLikes());
+    }
+
     // posts 데이터들을 PostsReadDto에 저장
     for (int i = 0; i < posts.size(); i++) {
       PostsReadDto postsReadDto = new PostsReadDto(posts.get(i));
     }
 
-    // 좋아요 수가 많은 3개의 Posts를 가져오기 위해서 likes 컬럼 기준으로 내림차순하고 Stream의 개수를 3개로 제한함
-    return postsRepository.findAllDesc().stream()
+    // 좋아요 수가 많은 3개의 Posts를 가져오기 위해서 likes 컬럼 기준으로 내림차순하고, 좋아요 수가 동일한 게시물일 경우 조회수를 기준으로 내림차순 하며, Stream의 개수를 3개로 제한함
+    return postsRepository.findAllDescByLikesAndView().stream()
         .map(PostsReadDto::new).limit(3)
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
기존에는 JOB담 커뮤니티 내에서 BEST3 게시물 선정을 위해서 좋아요 수 기준으로만 내림차순 정렬을 했다면, 변경된 코드에서는 좋아요 수가 같은 게시물일 경우 조회수가 더 많은 게시물이 먼저 출력될 수 있도록 정렬 기준을 추가했습니다.