### PR TITLE
[#284] 공모전 스크랩 기능 수정

### DIFF
--- a/src/main/java/com/gajob/controller/crawling/ExhibitScrapController.java
+++ b/src/main/java/com/gajob/controller/crawling/ExhibitScrapController.java
@@ -1,5 +1,6 @@
 package com.gajob.controller.crawling;
 
+import com.gajob.dto.crawling.ExhibitScrapDto;
 import com.gajob.service.crawling.ExhibitScrapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,26 @@ public class ExhibitScrapController {
 
     private final ExhibitScrapService exhibitScrapService;
 
+    @PostMapping("/scraps") // 공모전 스크랩 저장
+    public ResponseEntity save(@RequestBody ExhibitScrapDto exhibitScrapDto) {
+        return ResponseEntity.ok(exhibitScrapService.save(exhibitScrapDto));
+    }
+
+    @GetMapping("/scraps")  // 공모전 스크랩 전체 조회
+    public ResponseEntity getAllExhibitScraps() {
+        return ResponseEntity.ok(exhibitScrapService.getAllExhibitScraps());
+    }
+
+    @DeleteMapping("/scraps/{exhibitScrapId}")   // 공모전 스크랩 삭제
+    public ResponseEntity delete(@PathVariable Long exhibitScrapId) {
+        return ResponseEntity.ok(exhibitScrapService.delete(exhibitScrapId));
+    }
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
+
+    private final ExhibitScrapService exhibitScrapService;
+
     @PostMapping("/scraps/{exhibitFrameId}")  // 공모전 스크랩 기능
     public String scrap(@PathVariable Long exhibitFrameId) {
         return exhibitScrapService.scrap(exhibitFrameId);
@@ -22,5 +43,6 @@ public class ExhibitScrapController {
     public ResponseEntity getScrap() {
         return ResponseEntity.ok(exhibitScrapService.getScrap());
     }
+*/
 
 }

--- a/src/main/java/com/gajob/dto/crawling/ExhibitScrapDto.java
+++ b/src/main/java/com/gajob/dto/crawling/ExhibitScrapDto.java
@@ -1,0 +1,34 @@
+package com.gajob.dto.crawling;
+
+import com.gajob.entity.crawling.ExhibitScrap;
+import com.gajob.entity.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExhibitScrapDto {
+
+    private String title;
+    private String organization;
+    private Set categories;
+    private Set targets;
+    private String state;
+    private String todayState;
+    private String url;
+    private String imgUrl;
+    private User user;
+
+    public ExhibitScrap toEntity(User user) {
+        ExhibitScrap exhibitScrap = ExhibitScrap.builder().title(title).organization(organization).categories(categories)
+                .targets(targets).state(state).todayState(todayState).url(url).imgUrl(imgUrl).user(user).build();
+
+        return exhibitScrap;
+    }
+}

--- a/src/main/java/com/gajob/dto/crawling/ExhibitScrapResponseDto.java
+++ b/src/main/java/com/gajob/dto/crawling/ExhibitScrapResponseDto.java
@@ -3,8 +3,36 @@ package com.gajob.dto.crawling;
 import com.gajob.entity.crawling.ExhibitScrap;
 import lombok.Data;
 
+import java.util.Set;
+
 @Data
 public class ExhibitScrapResponseDto {
+
+    private Long id;
+    private String title;
+    private String organization;
+    private Set categories;
+    private Set targets;
+    private String state;
+    private String todayState;
+    private String url;
+    private String imgUrl;
+    private String scrapDate;
+
+    public ExhibitScrapResponseDto(ExhibitScrap exhibitScrap) {
+        this.id = exhibitScrap.getId();
+        this.title = exhibitScrap.getTitle();
+        this.organization = exhibitScrap.getOrganization();
+        this.targets = exhibitScrap.getTargets();
+        this.state = exhibitScrap.getState();
+        this.todayState = exhibitScrap.getTodayState();
+        this.url = exhibitScrap.getUrl();
+        this.imgUrl = exhibitScrap.getImgUrl();
+        this.scrapDate = exhibitScrap.getCreatedDate();
+    }
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
 
     private Long id;
     private String title;
@@ -17,5 +45,6 @@ public class ExhibitScrapResponseDto {
         this.scrapDate = exhibitScrap.getCreatedDate();
         this.exhibitUrl = "http://" + exhibitScrap.getExhibitFrame().getUrl();
     }
+*/
 
 }

--- a/src/main/java/com/gajob/entity/crawling/ExhibitScrap.java
+++ b/src/main/java/com/gajob/entity/crawling/ExhibitScrap.java
@@ -1,21 +1,63 @@
 package com.gajob.entity.crawling;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.gajob.entity.basetime.TimeEntity;
 import com.gajob.entity.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Getter
+@ToString
 @Entity
 public class ExhibitScrap extends TimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "exhibit_id")
+    private Long id;
+
+    @Column
+    private String title;   // 공모전 이름
+
+    @Column
+    private String organization;    // 공모전 주최기관
+
+    @ElementCollection
+    @CollectionTable(name = "exhibit_scrap_category", joinColumns = @JoinColumn(name = "exhibit_scrap_id"))
+    @Column(name = "category_name")
+    private Set<String> categories = new HashSet<>();   // 공모전 카테고리
+
+    @ElementCollection
+    @CollectionTable(name = "exhibit_scrap_target", joinColumns = @JoinColumn(name = "exhibit_scrap_id"))
+    @Column(name = "target_name")
+    private Set<String> targets = new HashSet<>(); // 공모전 참가대상
+
+    @Column
+    private String state;   // 공모전 진행상태
+
+    @Column
+    private String todayState;  // 공모전 오늘 진행상태
+
+    @Column
+    private String url; // 공모전 URL
+
+    @Column
+    private String imgUrl;  // 공모전 이미지 URL
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,5 +77,6 @@ public class ExhibitScrap extends TimeEntity {
         this.exhibitFrame = exhibitFrame;
         this.user = user;
     }
+*/
 
 }

--- a/src/main/java/com/gajob/repository/crawling/ExhibitScrapRepository.java
+++ b/src/main/java/com/gajob/repository/crawling/ExhibitScrapRepository.java
@@ -1,15 +1,12 @@
 package com.gajob.repository.crawling;
 
-import com.gajob.entity.crawling.ExhibitFrame;
 import com.gajob.entity.crawling.ExhibitScrap;
-import com.gajob.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface ExhibitScrapRepository extends JpaRepository<ExhibitScrap, Long> {
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
 
     @Query("select e from ExhibitScrap e")
     List<ExhibitScrap> findAll();
@@ -17,5 +14,6 @@ public interface ExhibitScrapRepository extends JpaRepository<ExhibitScrap, Long
     Optional<ExhibitScrap> findByUserAndExhibitFrame(User user, ExhibitFrame exhibitFrame);
 
     Optional<ExhibitScrap> deleteByUserAndExhibitFrame(User user, ExhibitFrame exhibitFrame);
+*/
 
 }

--- a/src/main/java/com/gajob/service/crawling/ExhibitScrapService.java
+++ b/src/main/java/com/gajob/service/crawling/ExhibitScrapService.java
@@ -1,13 +1,24 @@
 package com.gajob.service.crawling;
 
+import com.gajob.dto.crawling.ExhibitScrapDto;
 import com.gajob.dto.crawling.ExhibitScrapResponseDto;
 
 import java.util.List;
 
 public interface ExhibitScrapService {
 
+    ExhibitScrapResponseDto save(ExhibitScrapDto exhibitScrapDto);  // 공모전 스크랩 저장
+
+    List<ExhibitScrapResponseDto> getAllExhibitScraps();    // 공모전 스크랩 전체 조회
+
+    String delete(Long exhibitScrapId); // 공모전 스크랩 삭제
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
+
     String scrap(Long exhibitId);   // 공모전 스크랩 기능
 
     List<ExhibitScrapResponseDto> getScrap();   // 공모전 스크랩 목록 조회
+*/
 
 }

--- a/src/main/java/com/gajob/service/crawling/ExhibitScrapServiceImpl.java
+++ b/src/main/java/com/gajob/service/crawling/ExhibitScrapServiceImpl.java
@@ -1,10 +1,11 @@
 package com.gajob.service.crawling;
 
+import com.gajob.dto.crawling.ExhibitScrapDto;
 import com.gajob.dto.crawling.ExhibitScrapResponseDto;
-import com.gajob.entity.crawling.ExhibitFrame;
 import com.gajob.entity.crawling.ExhibitScrap;
 import com.gajob.entity.user.User;
-import com.gajob.repository.crawling.ExhibitFrameRepository;
+import com.gajob.enumtype.ErrorCode;
+import com.gajob.exception.CustomException;
 import com.gajob.repository.crawling.ExhibitScrapRepository;
 import com.gajob.repository.user.UserRepository;
 import com.gajob.util.SecurityUtil;
@@ -12,12 +13,61 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class ExhibitScrapServiceImpl implements ExhibitScrapService {
+
+    private final ExhibitScrapRepository exhibitScrapRepository;
+    private final UserRepository userRepository;
+
+    // 공모전 스크랩 정보를 DB에 저장
+    @Transactional
+    public ExhibitScrapResponseDto save(ExhibitScrapDto exhibitScrapDto) {
+        User user = userRepository.findOneWithAuthoritiesByEmail(
+                SecurityUtil.getCurrentUsername().get()).get();
+
+        return new ExhibitScrapResponseDto(exhibitScrapRepository.save(exhibitScrapDto.toEntity(user)));
+    }
+
+    // 저장한 공모전 스크랩 조회
+    @Transactional
+    public List<ExhibitScrapResponseDto> getAllExhibitScraps() {
+        List<ExhibitScrap> exhibitScraps = exhibitScrapRepository.findAll();
+
+        ArrayList<ExhibitScrapResponseDto> exhibitScrapResponseDtos = new ArrayList<ExhibitScrapResponseDto>();
+
+        for (ExhibitScrap exhibitScrapList : exhibitScraps) {
+            ExhibitScrapResponseDto exhibitScrapResponseDto = new ExhibitScrapResponseDto(exhibitScrapList);
+
+            exhibitScrapResponseDtos.add(exhibitScrapResponseDto);
+        }
+
+        return exhibitScrapResponseDtos;
+    }
+
+    // 저장한 공모전 스크랩 삭제
+    @Transactional
+    public String delete(Long exhibitScrapId) {
+        User user = userRepository.findOneWithAuthoritiesByEmail(
+                SecurityUtil.getCurrentUsername().get()).get();
+
+        ExhibitScrap exhibitScrap = exhibitScrapRepository.findById(exhibitScrapId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXHIBIT_ID_NOT_EXIST));
+
+        if (!(exhibitScrap.getUser().getEmail().equals(user.getEmail()))) {
+            throw new CustomException(ErrorCode.NO_ACCESS_RIGHTS);
+        }
+
+        exhibitScrapRepository.delete(exhibitScrap);
+
+        return "exhibit-scrap-delete";
+    }
+
+/*
+    -공모전 스크랩 기능(크롤링한 공모전 정보를 바로 스크랩)
 
     private final UserRepository userRepository;
     private final ExhibitFrameRepository exhibitFrameRepository;
@@ -54,5 +104,6 @@ public class ExhibitScrapServiceImpl implements ExhibitScrapService {
         return exhibitScrapRepository.findAll().stream().map(ExhibitScrapResponseDto::new).collect(
                 Collectors.toList());
     }
+*/
 
 }


### PR DESCRIPTION
기존에는 크롤링한 공모전 정보를 따로 저장할 수 있는 저장소로부터 스크랩이 가능하도록 구현했습니다.

하지만  이번에는 위에서 언급한 저장소를 삭제하고
request body에 공모전 정보를 바로 저장하여 스크랩할 수 있는 기능으로 수정했습니다.