### PR TITLE
[#289] 공모전 저장소 삭제(주석 처리)

### DIFF
--- a/src/main/java/com/gajob/controller/crawling/ExhibitFrameController.java
+++ b/src/main/java/com/gajob/controller/crawling/ExhibitFrameController.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.controller.crawling;
 
 import com.gajob.dto.crawling.ExhibitFrameDto;
@@ -30,3 +31,4 @@ public class ExhibitFrameController {
     }
 
 }
+*/

--- a/src/main/java/com/gajob/dto/crawling/ExhibitFrameDto.java
+++ b/src/main/java/com/gajob/dto/crawling/ExhibitFrameDto.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.dto.crawling;
 
 import com.gajob.entity.crawling.ExhibitFrame;
@@ -32,3 +33,4 @@ public class ExhibitFrameDto {
         return exhibitFrame;
     }
 }
+*/

--- a/src/main/java/com/gajob/dto/crawling/ExhibitFrameResponseDto.java
+++ b/src/main/java/com/gajob/dto/crawling/ExhibitFrameResponseDto.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.dto.crawling;
 
 import com.gajob.entity.crawling.ExhibitFrame;
@@ -29,3 +30,4 @@ public class ExhibitFrameResponseDto {
         this.imgUrl = exhibitFrame.getImgUrl();
     }
 }
+*/

--- a/src/main/java/com/gajob/entity/crawling/ExhibitFrame.java
+++ b/src/main/java/com/gajob/entity/crawling/ExhibitFrame.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.entity.crawling;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -56,3 +57,4 @@ public class ExhibitFrame {
     private User user;
 
 }
+*/

--- a/src/main/java/com/gajob/repository/crawling/ExhibitFrameRepository.java
+++ b/src/main/java/com/gajob/repository/crawling/ExhibitFrameRepository.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.repository.crawling;
 
 import com.gajob.entity.crawling.ExhibitFrame;
@@ -6,3 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ExhibitFrameRepository extends JpaRepository<ExhibitFrame, Long> {
 
 }
+*/

--- a/src/main/java/com/gajob/service/crawling/ExhibitFrameService.java
+++ b/src/main/java/com/gajob/service/crawling/ExhibitFrameService.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.service.crawling;
 
 import com.gajob.dto.crawling.ExhibitFrameDto;
@@ -14,3 +15,4 @@ public interface ExhibitFrameService {
     String delete(Long exhibitFrameId); // 공모전 정보 삭제
 
 }
+*/

--- a/src/main/java/com/gajob/service/crawling/ExhibitFrameServiceImpl.java
+++ b/src/main/java/com/gajob/service/crawling/ExhibitFrameServiceImpl.java
@@ -1,3 +1,4 @@
+/*
 package com.gajob.service.crawling;
 
 import com.gajob.dto.crawling.ExhibitFrameDto;
@@ -67,3 +68,4 @@ public class ExhibitFrameServiceImpl implements ExhibitFrameService {
     }
 
 }
+*/


### PR DESCRIPTION
크롤링한 공모전 정보를 저장할 수 있게 구현한 기능들을 주석처리한다.

(크롤링한 공모전을 스크랩 기능에서 바로 request body에 저장하여 관리하기로 함.)