### PR TITLE
[#301] 스터디 지원 내역 조회 시 데이터 추가

### DIFF
--- a/src/main/java/com/gajob/dto/study/StudyRecruitmentResponseDto.java
+++ b/src/main/java/com/gajob/dto/study/StudyRecruitmentResponseDto.java
@@ -25,6 +25,10 @@ public class StudyRecruitmentResponseDto {
 
   private Result result;
 
+  private Long postId;
+
+  private Long supplyId;
+
   public StudyRecruitmentResponseDto(StudyRecruitment studyRecruitment) {
     this.id = studyRecruitment.getId();
     this.name = studyRecruitment.getUser().getName();
@@ -35,5 +39,7 @@ public class StudyRecruitmentResponseDto {
     this.studentEmail = studyRecruitment.getUser().getStudentEmail();
     this.applicationDate = studyRecruitment.getCreatedDate();
     this.result = studyRecruitment.getResult();
+    this.postId = studyRecruitment.getStudy().getId();
+    this.supplyId = studyRecruitment.getId();
   }
 }


### PR DESCRIPTION
스터디 지원 내역 조회 시 지원한 게시물의 'postId'와 'supplyId'를 추가했습니다.