### PR TITLE
build.gradle update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation group: 'commons-io', name: 'commons-io', version: '2.4'
+    implementation 'mysql:mysql-connector-java:8.0.29'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools' // 임시 비밀번호 발급시 이메일 전송을 위해 추가
     runtimeOnly 'com.h2database:h2'


### PR DESCRIPTION
MySQL 버전과 현재 맥OS 버전의 충돌로 인해서 MySQL 오류로 인해 IntelliJ 가 작동되지 않는 에러가 발생했습니다.

build.gradle에 현재 MySQL의 버전 의존성을 주입하였더니 해당 문제가 해결되었습니다.